### PR TITLE
Fix url pour modifier la doc

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: Addon de streaming pour Kodi
 baseurl: "/" # the subpath of your site, e.g. /blog/
 url: https://kodi-vstream.github.io/ # the base hostname & protocol for your site
 git_address: https://github.com/kodi-vstream/kodi-vStream.github.io/
-git_edit_address: https://github.com/kodi-vstream/kodi-vStream.github.io/blob/gh-pages
+git_edit_address: https://github.com/kodi-vstream/kodi-vStream.github.io/blob/master
 
 # theme options from https://bootswatch.com/
 # comment out this to use default Bootstrap

--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -3,62 +3,61 @@ title: Installation
 permalink: /docs/installation/
 ---
 
-### Télécharger
-------
-
-[![images](https://img.shields.io/badge/T%C3%A9l%C3%A9charger-Repository-blue.svg?style=for-the-badge)](https://github.com/Kodi-vStream/venom-xbmc-addons/releases/tag/0.0.3)
-
 ### Installer le repository
 ---
+Tout d'abord, vous devez installer le repository qui contient **vStream**.
+Pour installer ce repository, vous avez le choix entre :
 
-- Depuis Home cliquer sur extensions puis sur l'icone de la petite boite.
+- Solution n°1 : Télécharger le repository directement en zip     
+     
+  [![images](https://img.shields.io/badge/T%C3%A9l%C3%A9charger-Repository-blue.svg?style=for-the-badge)](https://github.com/Kodi-vStream/venom-xbmc-addons/releases/tag/0.0.3)
+  
+   - Depuis le menu principal de Kodi, cliquer sur _Extensions_ puis sur l'icone de la petite boite   
+      
+     ![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_1.jpg)
+     
+    - Cliquer sur _Installer depuis un zip_
+    - Choisir le dossier local contenant _repository.vstream-x.x.x.zip   _ 
+        
+      ![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_2.jpg)
 
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_1.jpg)
+- Solution n°2 : Ajouter l'url où le repository est stocké à votre Gestionnaire de fichiers **Kodi**, pour cela suivre [Installation (URL)](https://kodi-vstream.github.io/docs/installation2/)
+   
+   - Choisir le dossier préalablement ajouté dans votre Gestionnaire de fichiers    
+       
+     ![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_repo6.jpg)
+     
+   - Choisir _repository.vstream-x.x.x.zip_
 
- - Installer depuis un zip.
 
+### Installer l'extension vStream
+---
 
-### Installer depuis un fichier .zip
-
- - Choisissez le dossier local contenant repository.vstream-x.x.x.zip
+ - Depuis le menu principal, cliquer sur _Extensions_ puis sur _Installer depuis un dépôt_.
  
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_2.jpg)
-
-
-### Installer depuis une Url
-
-- Choisisser le dossier créer avec l'adresse http://www.vstream.ml/repo/
-
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_repo6.jpg)
-
-
-### Installer l'addon vstream
-
- - Depuis Home cliquer sur extensions puis sur Installer depuis un dépôt.
- 
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_3.jpg)
+![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_3.jpg)
 
 
 
-- Sélectionner vStream Repository.
+- Sélectionner _vStream Repository_.
 
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_4.jpg)   
-
-
-
-- Sélectionner Extensions Vidéos.
-
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_5.jpg)
+![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_4.jpg)   
 
 
 
-- Sélectionner vStream.
+- Sélectionner _Extensions Vidéos_.
 
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_6.jpg)
+![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_5.jpg)
+
+
+
+- Sélectionner **vStream**.
+
+![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_6.jpg)
   
   
   
-- Sélectionner vStream / Installater
+- Sélectionner _Installer_
 
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_7.jpg)
+![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_7.jpg)
  

--- a/_docs/installation.md
+++ b/_docs/installation.md
@@ -3,7 +3,7 @@ title: Installation
 permalink: /docs/installation/
 ---
 
-### Installer le repository
+### 1. Installer le repository
 ---
 Tout d'abord, vous devez installer le repository qui contient **vStream**.
 Pour installer ce repository, vous avez le choix entre :
@@ -30,7 +30,7 @@ Pour installer ce repository, vous avez le choix entre :
    - Choisir _repository.vstream-x.x.x.zip_
 
 
-### Installer l'extension vStream
+### 2. Installer l'extension vStream
 ---
 
  - Depuis le menu principal, cliquer sur _Extensions_ puis sur _Installer depuis un dépôt_.

--- a/_docs/installation2.md
+++ b/_docs/installation2.md
@@ -6,28 +6,24 @@ permalink: /docs/installation2/
 ### Installer depuis une url
 ------
 
-- Url : http://www.vstream.ml/repo/
+- Url : https://kodi-vstream.github.io/repo/
 
-- Depuis Home cliquer sur Système puis sur Gestionnaire de fichier.
+- Depuis le menu principal, cliquer sur _Système_ puis sur _Gestionnaire de fichiers_.
 
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_repo.jpg)
+![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_repo.jpg)
 
-- Ajouter une Source.
+- Cliquer sur _Ajouter une source_.
 
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_repo1.jpg)
+![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_repo1.jpg)
 
-- Aucun 
+- Cliquer sur _Aucun_.
 
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_repo2.jpg)
+![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_repo2.jpg)
 
- - Entrer l'url http://www.vstream.ml/repo/
+ - Entrer l'url https://kodi-vstream.github.io/repo/
  
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_repo3.jpg)
-
- - Choisissez le nom donner au fichier ici Repository vstream
+ - Choisir le nom donné à la source, par exemple _Repository vStream_
  
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_repo4.jpg)
+![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/master/img/install_repo5.jpg)
 
-![images](https://github.com/Kodi-vStream/venom-xbmc-doc/raw/gh-pages/img/install_repo5.jpg)
-
-Pour la suite utiliser la methode [installater depuis un zip](http://vstream.ga/docs/installation/).
+Pour la suite, continuer à suivre où vous en étiez [Installer le repository](https://kodi-vstream.github.io/docs/installation/).


### PR DESCRIPTION
On ne peut pas modifier la doc en cliquant sur "Modifier cette page" sur le site.
Le lien du bouton "Modifier cette page" emmene sur une branche gh-pages qui n'existe pas, j'ai changé en master.

Sinon il faut renommer la branche master en gh-pages.